### PR TITLE
Bug/vue date formatting

### DIFF
--- a/data_aggregator/static/vue/mixins/utilities_mixin.js
+++ b/data_aggregator/static/vue/mixins/utilities_mixin.js
@@ -21,9 +21,12 @@ const utilitiesMixin = {
           return value ? new Date(value).toLocaleString('en-US', options) : '';
         },
         iso_date: function(value) {
-            let iso_date = new Date(new Date(value).toString().split('GMT')[0]+' UTC')
-                                    .toISOString().split('.')[0]+'Z';
-            return value ? iso_date : '';
+            let iso_date = '';
+            if(value) {
+              iso_date = new Date(new Date(value).toString().split('GMT')[0]+' UTC')
+                                  .toISOString().split('.')[0]+'Z';
+            }
+            return iso_date;
         }
     },
 }


### PR DESCRIPTION
Fix bug where the iso-date vue text format filter would break when jobs were reset.  The bug was because the date values were being set to '' when the filter expected a date string. 