### PR TITLE
Increase max memory to 2Gb

### DIFF
--- a/docker/test-values.yml
+++ b/docker/test-values.yml
@@ -43,7 +43,7 @@ targetAverageUtilization: 100
 resources:
   limits:
     cpu: 1000m
-    memory: 1024Mi
+    memory: 2048Mi
   requests:
     cpu: 50m
     memory: 256Mi


### PR DESCRIPTION
Increase max memory to 2Gb, to rule memory out as a reason why the create or update user management process gets killed