### PR TITLE
Increase the page refresh interval to not overwhelm the server

### DIFF
--- a/data_aggregator/static/vue/components/home/jobs-table.vue
+++ b/data_aggregator/static/vue/components/home/jobs-table.vue
@@ -33,12 +33,8 @@
         <b-form class="d-flex flex-nowrap" inline>
           <label class="ml-2 mr-2">Auto Refresh</label>
           <b-form-select v-model="refreshTime" id="refresh-select" name="refresh-select">
-            <b-form-select-option :value="5">5s</b-form-select-option>
-            <b-form-select-option :value="10">10s</b-form-select-option>
-            <b-form-select-option :value="15">15s</b-form-select-option>
-            <b-form-select-option :value="20">20s</b-form-select-option>
-            <b-form-select-option :value="25">25s</b-form-select-option>
             <b-form-select-option :value="30">30s</b-form-select-option>
+            <b-form-select-option :value="60">60s</b-form-select-option>
             <b-form-select-option :value="99999">Off</b-form-select-option>
           </b-form-select>
           <label class="ml-2 mr-2">Page Size</label>

--- a/data_aggregator/static/vue/home.js
+++ b/data_aggregator/static/vue/home.js
@@ -33,7 +33,7 @@ const store = new Vuex.Store({
     terms: JSON.parse(document.getElementById('terms').innerHTML), // job terms loaded on page load
     jobTypes: JSON.parse(document.getElementById('jobtypes').innerHTML), // job types loaded on page load
     jobRanges: JSON.parse(document.getElementById('job_ranges').innerHTML),
-    refreshTime: 5,
+    refreshTime: 30,
     // loading state
     isLoading: false, // toggles table loading indicator
     // data returned on each refresh


### PR DESCRIPTION
Refresh the jobs list every 30 seconds instead of every 5 seconds, in an attempt to no overwhelm the server