### PR TITLE
Update cronjob schedule to include db view creation commands

### DIFF
--- a/docker/test-values.yml
+++ b/docker/test-values.yml
@@ -61,13 +61,25 @@ cronjob:
       command: ["/scripts/management_command.sh"]
       args: ["create_or_update_users"]
     - name: add-assign-jobs
-      schedule: "0 10 * * 6" # At 2:00am PST on Saturday
+      schedule: "0 9 * * 6" # At 1:00am PST on Saturday
       command: ["/scripts/management_command.sh"]
       args: ["create_assignment_jobs"]
     - name: add-partic-jobs
-      schedule: "0 10 * * 6" # At 2:00am PST on Saturday
+      schedule: "0 9 * * 6" # At 1:00am PST on Saturday
       command: ["/scripts/management_command.sh"]
       args: ["create_participation_jobs"]
+    - name: add-assign-view
+      schedule: "0 20 * * 6" # At 12:00pm PST noon on Saturday
+      command: ["/scripts/management_command.sh"]
+      args: ["create_assignment_db_view"]
+    - name: add-partic-view
+      schedule: "0 20 * * 6" # At 12:00pm PST noon on Saturday
+      command: ["/scripts/management_command.sh"]
+      args: ["create_participation_db_view"]
+    - name: add-rad-view
+      schedule: "5 20 * * 6" # At 12:05pm PST noon on Saturday
+      command: ["/scripts/management_command.sh"]
+      args: ["create_rad_db_view"]
 daemon:
   enabled: true
   daemons:


### PR DESCRIPTION
Add create_assignment_db_view, create_participation_db_view, and create_rad_db_view management commands to cronjob schedule