### PR TITLE
Update webpack-bundler-tracker and webpack-loader to version 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/uwit-mci-axdd/django-container:1.3.1 as app-prewebpack-container
+FROM gcr.io/uwit-mci-axdd/django-container:1.3.1 as app-container
 
 USER root
 
@@ -24,12 +24,6 @@ ADD . /app/
 WORKDIR /app/
 RUN npm install .
 RUN npx webpack --mode=production
-
-FROM app-prewebpack-container as app-container
-
-COPY --chown=acait:acait --from=wpack /app/data_aggregator/static/data_aggregator/bundles/* /app/data_aggregator/static/data_aggregator/bundles/
-COPY --chown=acait:acait --from=wpack /app/data_aggregator/static/ /static/
-COPY --chown=acait:acait --from=wpack /app/data_aggregator/static/webpack-stats.json /app/data_aggregator/static/webpack-stats.json
 
 FROM gcr.io/uwit-mci-axdd/django-test-container:1.3.1 as app-test-container
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vue-underscore": "^0.1.4",
     "vuex": "^3.4.0",
     "webpack": "^4.42.1",
-    "webpack-bundle-tracker": "^0.4.3",
+    "webpack-bundle-tracker": "~1.0.0",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'UW-RestClients-PWS>=2.1.2,<3.0',
         'UW-RestClients-Canvas>=1.1.13,<2.0',
         'UW-Django-SAML2>=1.5.3,<2.0',
-        'django-webpack-loader>=0.7.0',
+        'django-webpack-loader>=1.0.0',
         'djangorestframework>=3.12.2,<4.0',
         'psycopg2~=2.8',
         'uw-gcs-clients>=1.0.0'


### PR DESCRIPTION
Updates webpack-bundler-tracker (npm) and webpack-loader (python) both to version 1.0.0. For more details see https://github.com/django-webpack/django-webpack-loader#migrating-from-version--100.