### PR TITLE
Simplify jobs date filtering

### DIFF
--- a/data_aggregator/static/vue/components/home/jobs-table.vue
+++ b/data_aggregator/static/vue/components/home/jobs-table.vue
@@ -108,42 +108,8 @@
               placeholder="All">
             </multiselect>
           </td>
-          <td colspan="2">
-            <date-range-picker
-              ref="jobspicker"
-              v-model="jobDateRange"
-              :opens="'left'"
-              :locale-data="dateLocale"
-              :singleDatePicker="false"
-              :showDropdowns="true"
-              :showWeekNumbers="true"
-              :ranges="false"
-              :timePicker="true"
-              :timePicker24Hour="true"
-              :linkedCalendars="true"
-              :autoApply="false"
-            >
-              <template v-slot:input="picker">
-                <template v-if="picker.startDate && picker.endDate">
-                  {{ picker.startDate | iso_date }} - {{ picker.endDate | iso_date}}
-                </template>
-                <template v-else>
-                  <span class="picker-placeholder"><b-icon-calendar></b-icon-calendar>  All</span>
-                </template>
-              </template>
-
-              <div slot="footer" slot-scope="data" class="picker-footer">
-                <span>
-                  {{data.rangeText}}
-                </span>
-                <span style="margin-left: auto">
-                  <a @click="data.clickCancel" class="btn btn-light btn-sm">Cancel</a>
-                  <a @click="clearJobDataPicker" class="btn btn-light btn-sm">Clear</a>
-                  <a @click="data.clickApply" v-if="!data.in_selection" class="btn btn-primary btn-sm">Apply</a>
-                </span>
-              </div>
-            </date-range-picker>
-          </td>
+          <td></td>
+          <td></td>
           <td></td>
         </template>
 
@@ -307,14 +273,6 @@ export default {
         this.$store.commit('setCurrPage', value);
       }
     },
-    jobDateRange: {
-      get () {
-        return this.$store.state.jobDateRange;
-      },
-      set (value) {
-        this.$store.commit('setJobDateRange', value);
-      }
-    },
   },
   methods: {
     handleAction: function() {
@@ -424,10 +382,6 @@ export default {
     },
     select: function() {
       this.allSelected = false;
-    },
-    clearJobDataPicker: function() {
-      this.jobDateRange = {startDate: null, endDate: null};
-      this.$refs.jobspicker.togglePicker(false);
     },
     _getColumnWidth: function(fieldKey) {
       if (fieldKey == "selected")

--- a/data_aggregator/static/vue/home.js
+++ b/data_aggregator/static/vue/home.js
@@ -58,10 +58,6 @@ const store = new Vuex.Store({
       startDate: null,
       endDate: null,
     },
-    jobDateRange: {
-      startDate: null,
-      endDate: null,
-    }
   },
   mutations: {
     setRefreshTime(state, value) {
@@ -111,15 +107,6 @@ const store = new Vuex.Store({
     },
     setActiveRangeEndDate(state, value) {
       state.activeDateRange.endDate = value;
-    },
-    setJobDateRange(state, value) {
-      state.jobDateRange = value;
-    },
-    setJobRangeStartDate(state, value) {
-      state.jobDateRange.startDate = value;
-    },
-    setJobRangeEndDate(state, value) {
-      state.jobDateRange.endDate = value;
     },
     addVarToState(state, {name, value}) {
       state[name] = value;
@@ -213,7 +200,6 @@ new Vue({
     ...mapState({
       refreshTime: (state) => state.refreshTime,
       activeDateRange: (state) => state.activeDateRange,
-      jobDateRange: (state) => state.jobDateRange,
       perPage: (state) => state.perPage,
       currPage: (state) => state.currPage,
       sortBy: (state) => state.sortBy,
@@ -229,7 +215,7 @@ new Vue({
     },
     selectionChangeTriggers: function() {
       // refresh if any of these change
-      return this.activeDateRange, this.jobDateRange,
+      return this.activeDateRange,
         this.currPage, this.perPage, this.sortBy, this.sortDesc, this.jobType,
         this.jobStatus;
     },
@@ -250,10 +236,6 @@ new Vue({
         "activeDateRange": {
           "startDate": utilities.parseIsoDateStr(this.activeDateRange.startDate),
           "endDate": utilities.parseIsoDateStr(this.activeDateRange.endDate),
-        },
-        "jobDateRange": {
-          "startDate": utilities.parseIsoDateStr(this.jobDateRange.startDate),
-          "endDate": utilities.parseIsoDateStr(this.jobDateRange.endDate),
         },
         "perPage": this.perPage,
         "currPage": this.currPage,
@@ -293,10 +275,6 @@ new Vue({
           "startDate": utilities.parseIsoDateStr(this.activeDateRange.startDate),
           "endDate": utilities.parseIsoDateStr(this.activeDateRange.endDate),
         },
-        "jobDateRange": {
-          "startDate": utilities.parseIsoDateStr(this.jobDateRange.startDate),
-          "endDate": utilities.parseIsoDateStr(this.jobDateRange.endDate),
-        },
         "jobType": this.jobType,
       })
       .then(response => {
@@ -331,12 +309,6 @@ new Vue({
         params['jobType'] = this.$store.state.jobType.join(",");
       if(this.$store.state.jobStatus.length > 0)
         params['jobStatus'] = this.$store.state.jobStatus.join(",");
-      if(this.$store.state.jobDateRange.startDate)
-        params['jobStartDate'] = utilities.toIsoDateStr(
-          this.$store.state.jobDateRange.startDate);
-      if(this.$store.state.jobDateRange.endDate)
-        params['jobEndDate'] = utilities.toIsoDateStr(
-          this.$store.state.jobDateRange.endDate)
       let queryParams = Object.keys(params).map(function(k) {
         return encodeURIComponent(k) + '=' + encodeURIComponent(params[k])
       }).join('&')

--- a/data_aggregator/utilities.py
+++ b/data_aggregator/utilities.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from datetime import date, datetime, timedelta, time
+from datetime import date, datetime, timedelta
 
 
 def datestring_to_datetime(date_str):

--- a/data_aggregator/views/api/jobs.py
+++ b/data_aggregator/views/api/jobs.py
@@ -4,8 +4,6 @@ from data_aggregator.views.api import RESTDispatch
 from data_aggregator.utilities import get_default_target_start, \
     get_default_target_end
 from django.db.models import F, Q, BooleanField, Value
-from django.utils import timezone
-from datetime import datetime, time
 
 
 def get_filtered_jobs_list(filters):
@@ -19,20 +17,13 @@ def get_filtered_jobs_list(filters):
     if activeDateRange:
         jobs = jobs.filter(
             target_date_start__lte=activeDateRange["endDate"]
-        )
-        jobs = jobs.filter(
+        ).filter(
             target_date_end__gte=activeDateRange["startDate"]
-        )
-
-    jobDateRange = filters.get('jobDateRange')
-    if jobDateRange.get("startDate") and \
-            jobDateRange.get("endDate"):
-        jobs = jobs.filter(
-            Q(start__lte=jobDateRange["endDate"]) |
+        ).filter(
+            Q(start__lte=activeDateRange["endDate"]) |
             Q(start__isnull=True)
-        )
-        jobs = jobs.filter(
-            Q(end__gte=jobDateRange["startDate"]) |
+        ).filter(
+            Q(end__gte=activeDateRange["startDate"]) |
             Q(end__isnull=True)
         )
 


### PR DESCRIPTION
When filtering jobs range check for both inclusivity of target start and end dates, as well as job start and end dates if present.