### PR TITLE
Greatly improve rad query performance by using a left outer join

### DIFF
--- a/data_aggregator/dao.py
+++ b/data_aggregator/dao.py
@@ -832,7 +832,7 @@ class TaskDAO(BaseDAO):
                             WHEN (COALESCE(cp.max_user_course_percentage, 0) - COALESCE(cp.min_user_course_percentage, 0)) = 0 THEN 0
                             ELSE ((COALESCE(up.user_course_percentage, 0) - COALESCE(cp.min_user_course_percentage, 0)) * 10) / (COALESCE(cp.max_user_course_percentage, 0) - COALESCE(cp.min_user_course_percentage, 0)) - 5
                         END AS normalized_user_course_percentage
-                    FROM user_percentages up join course_percentages cp on up.course_id = cp.course_id
+                    FROM user_percentages up LEFT OUTER JOIN course_percentages cp on up.course_id = cp.course_id
                     GROUP BY cp.course_id, up.user_id, normalized_user_course_percentage
                 )
                 SELECT


### PR DESCRIPTION
After some testing, this query returned the RAD db view in under 10 seconds, as opposed to over 3 minutes with the inner join. The problem was related to the query plan in the production db