### PR TITLE
Add build subaccount activity report management command subparser

### DIFF
--- a/data_aggregator/management/commands/_base.py
+++ b/data_aggregator/management/commands/_base.py
@@ -183,6 +183,10 @@ class CreateJobCommand(BaseCommand):
             subparsers, TaskTypes.create_rad_data_file, include_week=True)
 
         subparsers = self._add_subparser(
+            subparsers, TaskTypes.build_subaccount_activity_report,
+            include_account=True)
+
+        subparsers = self._add_subparser(
             subparsers, AnalyticTypes.assignment,
             include_week=True, include_course=True)
 


### PR DESCRIPTION
Adds missing build subaccount activity report subparser management command option so that task can be run