### PR TITLE
Default job context values

### DIFF
--- a/data_aggregator/dao.py
+++ b/data_aggregator/dao.py
@@ -426,8 +426,8 @@ class JobDAO(BaseDAO):
             LoadRadDAO().create_rad_data_file(sis_term_id=sis_term_id,
                                               week_num=week_num)
         elif job_type == TaskTypes.build_subaccount_activity_report:
-            ReportBuilder().build_subaccount_activity_report(subaccount_id,
-                                                             sis_term_id)
+            ReportBuilder().build_subaccount_activity_report(
+                subaccount_id, sis_term_id=sis_term_id, week_num=week_num)
         else:
             raise ValueError(f"Unknown job type {job_type}")
 

--- a/data_aggregator/dao.py
+++ b/data_aggregator/dao.py
@@ -416,9 +416,11 @@ class JobDAO(BaseDAO):
         elif job_type == TaskTypes.create_or_update_users:
             TaskDAO().create_or_update_users(sis_term_id=sis_term_id)
         elif job_type == TaskTypes.create_assignment_db_view:
-            TaskDAO().create_assignment_db_view(sis_term_id, week_num)
+            TaskDAO().create_assignment_db_view(sis_term_id=sis_term_id,
+                                                week_num=week_num)
         elif job_type == TaskTypes.create_participation_db_view:
-            TaskDAO().create_participation_db_view(sis_term_id, week_num)
+            TaskDAO().create_participation_db_view(sis_term_id=sis_term_id,
+                                                   week_num=week_num)
         elif job_type == TaskTypes.create_rad_db_view:
             TaskDAO().create_rad_db_view(sis_term_id=sis_term_id,
                                          week_num=week_num)
@@ -715,7 +717,7 @@ class TaskDAO(BaseDAO):
         logging.info(f"Updated {update_count} user(s).")
         return user_count
 
-    def create_rad_db_view(self, sis_term_id, week_num):
+    def create_rad_db_view(self, sis_term_id=None, week_num=None):
         """
         Create rad db view for given week and sis-term-id
 
@@ -848,7 +850,7 @@ class TaskDAO(BaseDAO):
         )
         return True
 
-    def create_participation_db_view(self, sis_term_id, week_num):
+    def create_participation_db_view(self, sis_term_id=None, week_num=None):
         """
         Create participation db view for given week and sis-term-id
 
@@ -908,7 +910,7 @@ class TaskDAO(BaseDAO):
         )
         return True
 
-    def create_assignment_db_view(self, sis_term_id, week_num):
+    def create_assignment_db_view(self, sis_term_id=None, week_num=None):
         """
         Create assignment db view for given week and sis-term-id
 

--- a/data_aggregator/models.py
+++ b/data_aggregator/models.py
@@ -14,6 +14,10 @@ from uw_sws import SWS_TIMEZONE
 
 class TermManager(models.Manager):
 
+    def get_current_term(self):
+        curr_date = timezone.now()
+        return self.get_term_for_date(curr_date)
+
     def get_term_for_date(self, date):
         """
         Return term intersecting with supplied date
@@ -37,8 +41,7 @@ class TermManager(models.Manager):
         """
         if sis_term_id is None:
             # try to lookup the current term based on the date
-            curr_date = timezone.now()
-            term = self.get_term_for_date(curr_date)
+            term = self.get_current_term()
             if term:
                 # return current term
                 return term, False
@@ -604,11 +607,14 @@ class RadDbView(models.Model):
 
 
 class ReportManager(models.Manager):
-    def get_or_create_report(self, report_type, sis_term_id=None):
+
+    def get_or_create_report(self, report_type,
+                             sis_term_id=None, week_num=None):
         term, _ = Term.objects.get_or_create_term_from_sis_term_id(
             sis_term_id=sis_term_id)
         week, _ = Week.objects.get_or_create_week(
-            sis_term_id=term.sis_term_id)
+            sis_term_id=term.sis_term_id,
+            week_num=week_num)
 
         if week.week < 1:
             raise TermNotStarted(term.sis_term_id)

--- a/data_aggregator/report_builder.py
+++ b/data_aggregator/report_builder.py
@@ -117,10 +117,13 @@ class ReportBuilder():
 
     @transaction.atomic
     @override_settings(RESTCLIENTS_CANVAS_TIMEOUT=90)
-    def build_subaccount_activity_report(self, root_account_id, sis_term_id):
+    def build_subaccount_activity_report(self, root_account_id,
+                                         sis_term_id=None, week_num=None):
         try:
             report = Report.objects.get_or_create_report(
-                Report.SUBACCOUNT_ACTIVITY, sis_term_id=sis_term_id)
+                Report.SUBACCOUNT_ACTIVITY,
+                sis_term_id=sis_term_id,
+                week_num=week_num)
         except TermNotStarted as ex:
             logger.info("Term {} not started".format(ex))
             return

--- a/data_aggregator/tests/test_assignment_view.py
+++ b/data_aggregator/tests/test_assignment_view.py
@@ -26,9 +26,9 @@ class TestAssignmentView(TestCase):
         td = TaskDAO()
         sis_term_id = "2013-spring"
         week = 1
-        td.create_assignment_db_view(sis_term_id, week)
+        td.create_assignment_db_view(sis_term_id=sis_term_id, week_num=week)
         week = 2
-        td.create_assignment_db_view(sis_term_id, week)
+        td.create_assignment_db_view(sis_term_id=sis_term_id, week_num=week)
         super().setUpTestData()
 
     def test_get_view_name(self):

--- a/data_aggregator/tests/test_dao.py
+++ b/data_aggregator/tests/test_dao.py
@@ -403,47 +403,67 @@ class TestJobDAO(TestCase):
         job = MagicMock()
         job.type = MagicMock()
         job.type.type = TaskTypes.create_terms
+        job.context = {
+            "sis_term_id": "2021-summer",
+            "week": 4,
+            "subaccount_id": "uwcourse"
+        }
+
         with patch("data_aggregator.dao.TaskDAO.create_terms") \
                 as mock_create_terms:
             JobDAO().run_task_job(job)
-            mock_create_terms.assert_called_once()
+            mock_create_terms.assert_called_once_with(
+                sis_term_id="2021-summer")
         job.type.type = TaskTypes.create_or_update_courses
         with patch("data_aggregator.dao.TaskDAO.create_or_update_courses") \
                 as mock_create_or_update_courses:
             JobDAO().run_task_job(job)
-            mock_create_or_update_courses.assert_called_once()
+            mock_create_or_update_courses.assert_called_once_with(
+                sis_term_id="2021-summer")
         job.type.type = TaskTypes.create_or_update_users
         with patch("data_aggregator.dao.TaskDAO.create_or_update_users") \
                 as mock_create_or_update_users:
             JobDAO().run_task_job(job)
-            mock_create_or_update_users.assert_called_once()
+            mock_create_or_update_users.assert_called_once_with(
+                sis_term_id="2021-summer")
         job.type.type = TaskTypes.create_assignment_db_view
         with patch("data_aggregator.dao.TaskDAO.create_assignment_db_view") \
                 as mock_create_assignment_db_view:
             JobDAO().run_task_job(job)
-            mock_create_assignment_db_view.assert_called_once()
+            mock_create_assignment_db_view.assert_called_once_with(
+                 sis_term_id="2021-summer",
+                 week_num=4)
         job.type.type = TaskTypes.create_participation_db_view
         with patch("data_aggregator.dao.TaskDAO."
                    "create_participation_db_view") \
                 as mock_create_participation_db_view:
             JobDAO().run_task_job(job)
-            mock_create_participation_db_view.assert_called_once()
+            mock_create_participation_db_view.assert_called_once_with(
+                 sis_term_id="2021-summer",
+                 week_num=4)
         job.type.type = TaskTypes.create_rad_db_view
         with patch("data_aggregator.dao.TaskDAO.create_rad_db_view") \
                 as mock_create_rad_db_view:
             JobDAO().run_task_job(job)
-            mock_create_rad_db_view.assert_called_once()
+            mock_create_rad_db_view.assert_called_once_with(
+                 sis_term_id="2021-summer",
+                 week_num=4)
         job.type.type = TaskTypes.create_rad_data_file
         with patch("data_aggregator.dao.LoadRadDAO.create_rad_data_file") \
                 as mock_create_rad_data_file:
             JobDAO().run_task_job(job)
-            mock_create_rad_data_file.assert_called_once()
+            mock_create_rad_data_file.assert_called_once_with(
+                 sis_term_id="2021-summer",
+                 week_num=4)
         job.type.type = TaskTypes.build_subaccount_activity_report
         with patch("data_aggregator.report_builder.ReportBuilder."
                    "build_subaccount_activity_report") \
                 as mock_build_subaccount_activity_report:
             JobDAO().run_task_job(job)
-            mock_build_subaccount_activity_report.assert_called_once()
+            mock_build_subaccount_activity_report.assert_called_once_with(
+                 "uwcourse",
+                 sis_term_id="2021-summer",
+                 week_num=4)
         job.type.type = "unknown-job-type"
         with self.assertRaises(ValueError):
             JobDAO().run_task_job(job)
@@ -507,13 +527,13 @@ class TestLoadRadDAO(TestCase):
         td = TaskDAO()
         sis_term_id = "2013-spring"
         week = 1
-        td.create_assignment_db_view(sis_term_id, week)
-        td.create_participation_db_view(sis_term_id, week)
-        td.create_rad_db_view(sis_term_id, week)
+        td.create_assignment_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_participation_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_rad_db_view(sis_term_id=sis_term_id, week_num=week)
         week = 2
-        td.create_assignment_db_view(sis_term_id, week)
-        td.create_participation_db_view(sis_term_id, week)
-        td.create_rad_db_view(sis_term_id, week)
+        td.create_assignment_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_participation_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_rad_db_view(sis_term_id=sis_term_id, week_num=week)
         super().setUpTestData()
 
     def _get_test_load_rad_dao(self):

--- a/data_aggregator/tests/test_participation_view.py
+++ b/data_aggregator/tests/test_participation_view.py
@@ -25,9 +25,9 @@ class TestParticipationView(TestCase):
         td = TaskDAO()
         sis_term_id = "2013-spring"
         week = 1
-        td.create_participation_db_view(sis_term_id, week)
+        td.create_participation_db_view(sis_term_id=sis_term_id, week_num=week)
         week = 2
-        td.create_participation_db_view(sis_term_id, week)
+        td.create_participation_db_view(sis_term_id=sis_term_id, week_num=week)
         super().setUpTestData()
 
     def test_get_view_name(self):

--- a/data_aggregator/tests/test_rad_view.py
+++ b/data_aggregator/tests/test_rad_view.py
@@ -25,13 +25,13 @@ class TestRadView(TestCase):
         td = TaskDAO()
         sis_term_id = "2013-spring"
         week = 1
-        td.create_assignment_db_view(sis_term_id, week)
-        td.create_participation_db_view(sis_term_id, week)
-        td.create_rad_db_view(sis_term_id, week)
+        td.create_assignment_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_participation_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_rad_db_view(sis_term_id=sis_term_id, week_num=week)
         week = 2
-        td.create_assignment_db_view(sis_term_id, week)
-        td.create_participation_db_view(sis_term_id, week)
-        td.create_rad_db_view(sis_term_id, week)
+        td.create_assignment_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_participation_db_view(sis_term_id=sis_term_id, week_num=week)
+        td.create_rad_db_view(sis_term_id=sis_term_id, week_num=week)
         super().setUpTestData()
 
     def test_get_view_name(self):


### PR DESCRIPTION
Define default term and week values when they are required for a job but not passed on the command line. Defaults to current term and week.