### PR TITLE
Fix for case where current term isn't in database

### DIFF
--- a/data_aggregator/management/commands/_base.py
+++ b/data_aggregator/management/commands/_base.py
@@ -102,7 +102,7 @@ class CreateJobCommand(BaseCommand):
         # when processing the command
         if include_week or include_term:
             # use current term and week of term as the default
-            term = Term.objects.get_current_term()
+            term, _ = Term.objects.get_or_create_term_from_sis_term_id()
             default_sis_term_id = term.sis_term_id
             default_week = get_relative_week(term.first_day_quarter,
                                              tz_name="US/Pacific")


### PR DESCRIPTION
Fix bug where creating jobs would fail if the current term wasn't in the database